### PR TITLE
add-autocomplete-option-for-city-field issue #10

### DIFF
--- a/patients/templates/patients/report.html
+++ b/patients/templates/patients/report.html
@@ -8,7 +8,23 @@
 {% endblock %}
 
 {% block JS %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js"></script> <!--helps to AutoComplete -->
   <script>
+    // Start : AutoComplete Citys
+    var ajax = new XMLHttpRequest();
+    var city_data = "https://indian-cities-api-nocbegfhqg.now.sh/cities"
+    ajax.open("GET", city_data, true);
+    ajax.onload = function() {
+      citys = JSON.parse(ajax.responseText);
+      list = citys.map(function(entry) {
+        name = entry.City;
+        return name;
+      });
+      var input = document.getElementById("id_detected_city");
+      new Awesomplete(input, { list: list });
+    }; ajax.send();
+    //End : AutoComplete Citys
+
     $(document).ready(function() {
       $("#id_detected_state").change(function() {
         var selected_state = $("#id_detected_state").val();


### PR DESCRIPTION
> This PR refers #10 

### This PR contains

1. added the auto-complete option for city field (only for template view)

>`Note` 
I will try to implement this option in admin view also, currently, end users can use this option.
--
I used[ awesomecomplete js](https://github.com/LeaVerou/awesomplete) and the dataset we are using is from https://indian-cities-api-nocbegfhqg.now.sh/cities (got from the discussion on #10 by @vijaysaimutyala )

#### Live Demo
http://39fe620a.ngrok.io/report

#### Screenshot
![Screenshot from 2020-03-22 18-04-40](https://user-images.githubusercontent.com/28041916/77249563-f1a86e00-6c67-11ea-83ce-b446de024075.png)
