### PR TITLE
Update settings.py

### DIFF
--- a/CovidCrowd/settings.py
+++ b/CovidCrowd/settings.py
@@ -164,12 +164,12 @@ REST_FRAMEWORK = {
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
+        'LOCATION': 'localhost:11211',
     }
 }
 
 INTERNAL_IPS = [
-    '127.0.0.1',
+    'localhost',
 ]
 
 CORS_ORIGIN_WHITELIST = [


### PR DESCRIPTION
Changed  127.0.0.1 to localhost because 127.0. 0.1 is the loopback Internet protocol (IP) address also referred to as the localhost.
127.0.0.1    localhost

The hostname localhost is used to access the network services running on a host through the loopback network interface.Ordinarily only the address 127.0.0.1 is used for loopack. But you can change the loopback IP address to some other IP address by modifying the network configuration of the loopback network adapter and then pointing the localhost to the new IP address in the hosts file.
so it will more rellevent to use localhost